### PR TITLE
Complete the task type rename to ROS2

### DIFF
--- a/src/build-tool/ros-shell.ts
+++ b/src/build-tool/ros-shell.ts
@@ -16,11 +16,11 @@ export class RosShellTaskProvider implements vscode.TaskProvider {
     }
 
     public defaultRosTasks(): vscode.Task[] {
-        const rosCore = make('ros core', {type: 'RDE', command: 'roscore'}, 'roscore');
+        const rosCore = make('ros core', {type: 'ROS2', command: 'roscore'}, 'roscore');
         rosCore.isBackground = true;
         rosCore.problemMatchers = ['$roscore'];
 
-        const rosLaunch = make('ros launch', {type: 'RDE', command: 'roslaunch', args: ['package_name', 'launch_file.launch']}, 'roslaunch');
+        const rosLaunch = make('ros launch', {type: 'ROS2', command: 'roslaunch', args: ['package_name', 'launch_file.launch']}, 'roslaunch');
         rosLaunch.isBackground = true;
         rosLaunch.problemMatchers = ['$roslaunch'];
 
@@ -34,7 +34,7 @@ export class RosShellTaskProvider implements vscode.TaskProvider {
 
 export function registerRosShellTaskProvider(): vscode.Disposable[] {
     return [
-        vscode.tasks.registerTaskProvider('RDE', new RosShellTaskProvider()),
+        vscode.tasks.registerTaskProvider('ROS2', new RosShellTaskProvider()),
     ];
 }
 


### PR DESCRIPTION
# Issue
Name of the task type has been changed from `RDE` to `ROS2` in `packckage.json` however it was not renamed in the task provider code.
This resulted in neither RDE nor ROS2 tasks working as ros-shell, essentially breaking most of the extension functionality.

# Solution
Rename task type to `ROS2` in the task provider and use it in the rosCore and rosLaunch as well.

## Testing

Tested locally by building vsix using `vcse package`
Platform: macOS host with ROS2 jazzy [devcontainer in Dr.QP project](https://github.com/Dr-QP/Dr.QP/blob/main/.devcontainer/devcontainer.json)