### PR TITLE
Fix incorrect doc links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,6 @@ This is a Visual Studio Code Extension that  provides debugging support for [Rob
 * Syntax highlighting for `.msg`, `.urdf` and other ROS files.
 * Automatically add the ROS C++ include and Python import paths.
 * Format C++ using the ROS `clang-format` style.
-* Debug a single ROS node (C++ or Python) by [attaching to the process][debug_support-attach].
-* Debug ROS nodes (C++ or Python) [launched from a `.launch` file][debug_support-launch].
+* Debug a single ROS node (C++ or Python) by [attaching to the process](debug-support.md#attach).
+* Debug ROS nodes (C++ or Python) [launched from a `.launch` file](debug-support.md#launch).
 * Configure Intellisense

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 # Robotics Development Extensions for ROS 2
-This is a Visual Studio Code Extension that  provides debugging support for [Robot Operating System 2 (ROS 2)][http://ros.org] development ROS 2 on Windows, Linux and MacOS. The Robot Operating System is a trademark of Open Robotics.
+This is a Visual Studio Code Extension that  provides debugging support for [Robot Operating System 2 (ROS 2)](http://ros.org) development ROS 2 on Windows, Linux and MacOS. The Robot Operating System is a trademark of Open Robotics.
 
 > NOTE: This extension is rebranded and re-released by Ranch Hand Robotics, owned by the maintainer of the [ms-iot VSCode ROS Extension](https://github.com/ms-iot/vscode-ros) with permission from Microsoft. The source extension was split into 3 parts - [ROS 1](https://ranchhandrobotics.github.io/rde-ros-1/), [ROS 2](https://ranchhandrobotics.github.io/rde-ros-2/) and a [URDF editor](https://ranchhandrobotics.github.io/rde-urdf/).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Robotics Development Extensions for ROS 2
 This is a Visual Studio Code Extension that  provides debugging support for [Robot Operating System 2 (ROS 2)](http://ros.org) development ROS 2 on Windows, Linux and MacOS. The Robot Operating System is a trademark of Open Robotics.
 
-> NOTE: This extension is rebranded and re-released by Ranch Hand Robotics, owned by the maintainer of the [ms-iot VSCode ROS Extension](https://github.com/ms-iot/vscode-ros) with permission from Microsoft. The source extension was split into 3 parts - [ROS 1](https://ranchhandrobotics.github.io/rde-ros-1/), [ROS 2](https://ranchhandrobotics.github.io/rde-ros-2/) and a [URDF editor](https://ranchhandrobotics.github.io/rde-urdf/).
+> NOTE: This extension is rebranded and re-released by Ranch Hand Robotics, owned by the maintainer of the [ms-iot VSCode ROS Extension](https://github.com/ms-iot/vscode-ros) with permission from Microsoft. The source extension was split into 3 parts - [ROS 1](https://ranchhandrobotics.com/rde-ros-1/), [ROS 2](https://ranchhandrobotics.com/rde-ros-2/) and a [URDF editor](https://ranchhandrobotics.com/rde-urdf/).
 
 ## Features
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -2,8 +2,8 @@
 
 | Name | Description |
 |---|:---|
-| [Attaching to a running ROS Node](https://github.com/ranchhandrobotics/rde-ros-2/blob/main/docs/debug-support.md) | Learn how to attach VS Code to a running ROS node |
-| [Debugging all ROS Nodes in a launch file ](https://github.com/ranchhandrobotics/rde-ros-2/blob/main/docs/debug-support.md) | Learn how to set up VS Code to debug the nodes in a ROS Launch file |
+| [Attaching to a running ROS Node](debug-support.md#attach) | Learn how to attach VS Code to a running ROS node |
+| [Debugging all ROS Nodes in a launch file](debug-support.md#launch) | Learn how to set up VS Code to debug the nodes in a ROS Launch file |
 | [ROSCON 2019 ROS Extension Talk Video](https://vimeopro.com/osrfoundation/roscon-2019/video/379127667) | Walkthrough of VS Code from ROSCon 2019|
 | [Deep Dive - Episode 0](https://youtu.be/PBbEhRf8QjE) |  About the VS Code ROS extension @ a Polyhobbyist |
 | [Deep Dive - Episode 1](https://youtu.be/bupAju0UAMg) |  Installing on Windows & WSL @ a Polyhobbyist |


### PR DESCRIPTION
Fix of incorrect links on docs, probably unchanged after some kind of update, and overall improvement on links.
Some problems were:
- Links to web pages were using square brackets instead of parenthesis
- Links to other pages of the same docs didn't exist
- Links to headers of other pages of the docs were incorrect