### PR TITLE
Fix bug when using custom tasks

### DIFF
--- a/src/build-tool/ros-shell.ts
+++ b/src/build-tool/ros-shell.ts
@@ -40,6 +40,7 @@ export function registerRosShellTaskProvider(): vscode.Disposable[] {
 
 export function resolve(task: vscode.Task): vscode.Task {
     let definition = task.definition as RosTaskDefinition
+    definition.command = definition.command || definition.type;
     const resolvedTask = make(definition.command, definition);
 
     resolvedTask.isBackground = task.isBackground;


### PR DESCRIPTION
When using a custom build task (for instance if I want to add compile commands to the colcon build), the following error results when attempting to run it "There is no task provider registered for tasks of type colcon"

Original issue is https://github.com/Ranch-Hand-Robotics/rde-ros-1/issues/30 (That is for ROS1 version but it's also an issue in ROS2)

The issue is that command is not set when a custom task is created