### PR TITLE
Use CMAKE_PREFIX_PATH instead of AMENT_PREFIX_PATH to generate include dirs

### DIFF
--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -65,8 +65,9 @@ export class ROS2 implements ros.ROSApi {
 
     public async getIncludeDirs(): Promise<string[]> {
         const prefixPaths: string[] = [];
-        if (this.env.AMENT_PREFIX_PATH) {
-            prefixPaths.push(...this.env.AMENT_PREFIX_PATH.split(path.delimiter));
+        const envPrefixPath = this.env.CMAKE_PREFIX_PATH;
+        if (envPrefixPath) {
+            prefixPaths.push(...envPrefixPath.split(path.delimiter));
         }
 
         const includeDirs: string[] = [];


### PR DESCRIPTION
When using the command `ROS2.updateCppProperties`, the element `configurations.includePath` of the `.vscode/c_cpp_properties.json` is generated based on the value of the environment variable `AMENT_PREFIX_PATH`. This variable includes the path of the install directory of each package defined in all underlay workspaces.

However, it is possible to define cmake packages without using ament_cmake. It can be useful, for example, to create libraries that does not depend on a specific ROS version. The problem is that these packages are not defined in `AMENT_PREFIX_PATH` and will be forgotten in `includePath`. I think it is better to use `CMAKE_PREFIX_PATH` instead of the ament one because this one includes all the cmake packages.