### PR TITLE
Fix vsix package name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build Prerelease VSIX package
         if: ${{ github.event.inputs.prerelease == 'true' }}
         run: |
-          vsce package --pre-release -o rde-urdf-${{ github.event.inputs.tags }}-pre.vsix
+          vsce package --pre-release -o rde-ros-2-${{ github.event.inputs.tags }}-pre.vsix
       
       - name: Publish Prerelease to Marketplace
         if: ${{ github.event.inputs.prerelease == 'true' }}
@@ -56,13 +56,13 @@ jobs:
               --title="Prerelease ${{ github.event.inputs.tags }}" \
               --generate-notes \
               --prerelease \
-              rde-urdf-${{ github.event.inputs.tags }}-pre.vsix
+              rde-ros-2-${{ github.event.inputs.tags }}-pre.vsix
       
       # Release flow
       - name: Build Release VSIX package
         if: ${{ github.event.inputs.prerelease == 'false' }}
         run: |
-          vsce package -o rde-urdf-${{ github.event.inputs.tags }}.vsix
+          vsce package -o rde-ros-2-${{ github.event.inputs.tags }}.vsix
       
       - name: Publish Release to Marketplace
         if: ${{ github.event.inputs.prerelease == 'false' }}
@@ -79,4 +79,4 @@ jobs:
               --repo="$GITHUB_REPOSITORY" \
               --title="Release ${{ github.event.inputs.tags }}" \
               --generate-notes \
-              rde-urdf-${{ github.event.inputs.tags }}.vsix
+              rde-ros-2-${{ github.event.inputs.tags }}.vsix


### PR DESCRIPTION
Hi! Thank you for maintaining this project.

I noticed the VSIX asset filename on the GitHub Releases page was incorrect due to the current GitHub Actions configuration. This PR updates the workflow so the uploaded VSIX uses the expected filename.

Current: `rde-urdf-<version>vsix`

Proposed: `rde-ros-2-<version>.vsix`

This change helps prevent confusion with other VSIX files.