### PR TITLE
Revert "Use CMAKE_PREFIX_PATH instead of AMENT_PREFIX_PATH to generate include dirs"

### DIFF
--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -65,9 +65,8 @@ export class ROS2 implements ros.ROSApi {
 
     public async getIncludeDirs(): Promise<string[]> {
         const prefixPaths: string[] = [];
-        const envPrefixPath = this.env.CMAKE_PREFIX_PATH;
-        if (envPrefixPath) {
-            prefixPaths.push(...envPrefixPath.split(path.delimiter));
+        if (this.env.AMENT_PREFIX_PATH) {
+            prefixPaths.push(...this.env.AMENT_PREFIX_PATH.split(path.delimiter));
         }
 
         const includeDirs: string[] = [];


### PR DESCRIPTION
Reverting this PR until we understand the impact relative to a new PR